### PR TITLE
fix: Fix an issue where the filter list is inaccessible at full width

### DIFF
--- a/app/views/library/index.html.erb
+++ b/app/views/library/index.html.erb
@@ -22,13 +22,13 @@
   </section>
 
   <div class="max-w-7xl mx-auto px-6 py-8" data-controller="sidebar">
-    <div class="fixed inset-0 bg-black bg-opacity-50 z-40 hidden"
+    <div class="fixed inset-0 bg-black bg-opacity-50 z-40 hidden lg:hidden"
          data-sidebar-target="overlay"
          data-action="click->sidebar#close"></div>
 
     <div class="flex gap-8">
       <!-- Sidebar Filters -->
-      <aside class="w-80 flex-shrink-0 fixed top-0 left-0 h-full bg-white z-50 transform -translate-x-full transition-transform duration-300 overflow-y-auto"
+      <aside class="w-80 flex-shrink-0 fixed top-0 left-0 h-full bg-white z-50 -translate-x-full overflow-y-auto lg:static lg:translate-x-0 lg:h-auto lg:z-auto"
              data-sidebar-target="sidebar"
              aria-label="Filter options">
         <div id="filters_list">


### PR DESCRIPTION
Current behaviour:
<img width="1434" height="995" alt="image" src="https://github.com/user-attachments/assets/77c78b08-e89e-4be3-97ae-1739a140e1f1" />

Fix:
<img width="1437" height="986" alt="image" src="https://github.com/user-attachments/assets/5436db76-a54d-4b36-92da-e3d773fecbd5" />
